### PR TITLE
FL2 "C5 sensors" patch

### DIFF
--- a/Dependencies/LibreTransmitter/Sources/LibreTransmitter/Bluetooth/LibreTransmitterMetadata.swift
+++ b/Dependencies/LibreTransmitter/Sources/LibreTransmitter/Bluetooth/LibreTransmitterMetadata.swift
@@ -80,6 +80,7 @@ public enum SensorType: String, CustomStringConvertible {
     case libre1    = "DF"
     case libre1A2 =  "A2"
     case libre2    = "9D"
+    case libre2C5 = "C5"
     case libreUS14day   = "E5"
     case libreUS14dayE6 = "E6"
     case libreProH = "70"
@@ -90,7 +91,7 @@ public enum SensorType: String, CustomStringConvertible {
             return "Libre 1"
         case .libre1A2:
             return "Libre 1 A2"
-        case .libre2:
+        case .libre2, .libre2C5:
             return "Libre 2"
         case .libreUS14day, .libreUS14dayE6:
             return "Libre US"
@@ -106,7 +107,7 @@ public extension SensorType {
 
         let start = patchInfo[0..<2].uppercased()
 
-        let choices: [String: SensorType] = ["DF": .libre1, "A2": .libre1A2, "9D": .libre2, "E5": .libreUS14day, "E6": .libreUS14dayE6, "70": .libreProH]
+        let choices: [String: SensorType] = ["DF": .libre1, "A2": .libre1A2, "9D": .libre2, "C5": .libre2, "E5": .libreUS14day, "E6": .libreUS14dayE6, "70": .libreProH]
 
         if let res = choices[start] {
             self = res

--- a/Dependencies/LibreTransmitter/Sources/LibreTransmitter/LibreSensor/SensorContents/PreLibre2.swift
+++ b/Dependencies/LibreTransmitter/Sources/LibreTransmitter/LibreSensor/SensorContents/PreLibre2.swift
@@ -9,7 +9,7 @@ public enum Libre2 {
     ///   - data: Encrypted FRAM data
     /// - Returns: Decrypted FRAM data
     static public func decryptFRAM(type: SensorType, id: [UInt8], info: [UInt8], data: [UInt8]) throws -> [UInt8] {
-        guard type == .libre2 || type == .libreUS14day || type == .libreUS14dayE6 else {
+        guard type == .libre2 || type == .libre2C5 || type == .libreUS14day || type == .libreUS14dayE6 else {
             struct DecryptFRAMError: Error {
                 let errorDescription = "Unsupported sensor type"
             }
@@ -24,7 +24,7 @@ public enum Libre2 {
                     return 0xcadc
                 }
                 return UInt16(info[5], info[4])
-            case .libre2:
+            case .libre2, .libre2C5:
                 return UInt16(info[5], info[4]) ^ 0x44
             default: fatalError("Unsupported sensor type")
             }


### PR DESCRIPTION
Added code from [https://github.com/Artificial-Pancreas/iAPS/pull/104/commits/fa9ec6805a258e31dec50f23a5c924431eb220b3](url) to support newer European Freestyle Libre 2 sensors ( "C5" )

